### PR TITLE
KP-8598 Implemented ability to delete draft requests

### DIFF
--- a/portal/src/App.jsx
+++ b/portal/src/App.jsx
@@ -120,7 +120,7 @@ export const App = ({
 
         <main
           id="app-main"
-          className="flex flex-col flex-auto relative overflow-auto scrollbar"
+          className="flex flex-col flex-auto relative overflow-y-auto overflow-x-hidden scrollbar"
         >
           {serverError || error ? (
             // If an error occurred during auth or fetching app data, show an

--- a/portal/src/atoms/Modal.jsx
+++ b/portal/src/atoms/Modal.jsx
@@ -94,7 +94,10 @@ export const Modal = ({
               </Dialog.CloseTrigger>
             </div>
             {slots.description && (
-              <Dialog.Description asChild>
+              <Dialog.Description
+                asChild
+                className="overflow-auto scrollbar-white py-3 px-6"
+              >
                 {slots.description}
               </Dialog.Description>
             )}

--- a/portal/src/components/forms/FormLayout.jsx
+++ b/portal/src/components/forms/FormLayout.jsx
@@ -8,12 +8,16 @@ import { Icon } from '../../atoms/Icon.jsx';
 /**
  * Generates a Layout component for CoreForm.
  *
- * @param {JSX.FC} [Heading] Additional component(s) to
+ * @param {Object} [options]
+ * @param {React.FC} [options.actionComponent] Additional component to render
+ *  in the top right corner of the heading of the form layout.
+ * @param {React.FC} [options.headingComponent] Additional component(s) to
  *  render in the heading of the form layout.
- * @param {string} [backTo] Path that the back button should use.
+ * @param {string} [options.backTo] Path that the back button should use.
  * @returns {function({form: Object, content: (JSX.Element|JSX.Element[])}): *}
  */
 export const generateFormLayout = ({
+  actionComponent: Action,
   headingComponent: Heading,
   backTo,
 } = {}) => {
@@ -21,10 +25,13 @@ export const generateFormLayout = ({
    * Generate a FormLayout component to be used by the CoreForm component. The
    * props passed into this component are provided by CoreForm.
    *
-   * @param {Object} form The Kinetic form record
-   * @param {JSX.Element|JSX.Element[]} content The form content to render.
+   * @param {Object} options
+   * @param {Object} options.form The Kinetic form record
+   * @param {Object} options.submission The Kinetic submission record
+   * @param {JSX.Element|JSX.Element[]} options.content The form content to
+   *  render.
    */
-  const FormLayout = ({ form, content }) => {
+  const FormLayout = ({ form, submission, content }) => {
     const location = useLocation();
     const backPath = location.state?.backPath;
     const icon = getAttributeValue(form, 'Icon', 'forms');
@@ -63,7 +70,15 @@ export const generateFormLayout = ({
             <div className="bg-primary-100 border border-primary-400 text-primary-900 rounded-[10px] shadow-icon flex-none p-2.25">
               <Icon name={form ? icon : 'blank'} />
             </div>
-            <span className="flex-1"></span>
+            <span className="flex-1 text-right">
+              {Action && (
+                <Action
+                  form={form}
+                  submission={submission}
+                  backTo={backTo || backPath}
+                />
+              )}
+            </span>
           </div>
           <div className="max-w-screen-md text-base md:text-h3 font-semibold">
             {form?.name}
@@ -73,7 +88,11 @@ export const generateFormLayout = ({
           </div>
           {form && Heading && (
             <div className="max-w-screen-md">
-              <Heading />
+              <Heading
+                form={form}
+                submission={submission}
+                backTo={backTo || backPath}
+              />
             </div>
           )}
         </div>
@@ -97,6 +116,7 @@ export const generateFormLayout = ({
 
   FormLayout.propTypes = {
     form: t.object,
+    submission: t.object,
     content: t.any,
   };
 

--- a/portal/src/components/tickets/StatusPill.jsx
+++ b/portal/src/components/tickets/StatusPill.jsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import t from 'prop-types';
 
-export const StatusPill = ({ status }) => (
+export const StatusPill = ({ className, status }) => (
   <div
     className={clsx(
       // Mobile first styles
@@ -16,6 +16,7 @@ export const StatusPill = ({ status }) => (
           status === 'Submitted' || status === 'Open',
         'bg-gray-200 text-gray-900 border-gray-500': status === 'Closed',
       },
+      className,
     )}
   >
     {status}

--- a/portal/src/helpers/useSwipe.js
+++ b/portal/src/helpers/useSwipe.js
@@ -1,0 +1,84 @@
+import { useCallback, useState } from 'react';
+import { callIfFn } from './index.js';
+
+/**
+ * Provides swipe functionality to allow triggering callbacks when an item is
+ *  swiped a certain distance and direction.
+ *
+ * @param {Object} [options]
+ * @param {number} [options.threshold] The distance the swipe must pass for a
+ *  callback to be triggered.
+ * @param {Function} [options.onLeftSwipe] The callback to trigger when the
+ *  swipe is in the left direction and passes the `threshold` distance.
+ * @param {Function} [options.onRightSwipe] The callback to trigger when the
+ *  swipe is in the right direction and passes the `threshold` distance.
+ * @returns {SwipeState} A state object of relevant data and event handlers for
+ *  the swipe functionality.
+ */
+const useSwipe = ({ threshold = 64, onLeftSwipe, onRightSwipe } = {}) => {
+  if (typeof threshold !== 'number' || threshold < 1) {
+    throw new Error('useSwipe requires `threshold` to be a positive number');
+  }
+
+  const [startX, setStartX] = useState(null);
+  const [endX, setEndX] = useState(null);
+
+  const resetX = useCallback(() => {
+    setEndX(null);
+    setStartX(null);
+  }, []);
+
+  const onTouchStart = e => {
+    setEndX(e.targetTouches[0].clientX);
+    setStartX(e.targetTouches[0].clientX);
+  };
+
+  const onTouchMove = e => setEndX(e.targetTouches[0].clientX);
+
+  const onTouchEnd = () => {
+    if (!startX || !endX) return;
+    const distance = startX - endX;
+
+    // If swiped left
+    if (distance >= threshold) {
+      callIfFn(onLeftSwipe);
+    }
+
+    // If swiped right
+    if (distance + threshold <= 0) {
+      callIfFn(onRightSwipe);
+    }
+
+    resetX();
+  };
+
+  const active = startX && endX;
+  const distance = active ? startX - endX : 0;
+
+  return {
+    left:
+      typeof onLeftSwipe === 'function' && distance > 0
+        ? Math.max(distance * -1, threshold * -1)
+        : undefined,
+    right:
+      typeof onRightSwipe === 'function' && distance < 0
+        ? Math.max(distance, threshold * -1)
+        : undefined,
+    onTouchStart,
+    onTouchMove,
+    onTouchEnd,
+  };
+};
+
+export default useSwipe;
+
+/**
+ * @typedef {Object} SwipeState The state of the swipe event.
+ * @property {Function} onTouchStart Event handler to pass to the swipable item.
+ * @property {Function} onTouchMove Event handler to pass to the swipable item.
+ * @property {Function} onTouchEnd Event handler to pass to the swipable item.
+ * @property {number} left Left offset for the item representing the distance
+ *  swiped in that direction.
+ * @property {number} right Right offset for the item representing the distance
+ *  swiped in that direction.
+ */

--- a/portal/src/pages/forms/Form.jsx
+++ b/portal/src/pages/forms/Form.jsx
@@ -1,10 +1,61 @@
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { useSelector } from 'react-redux';
-import { KineticForm } from '../../components/kinetic-form/KineticForm.jsx';
 import { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { deleteSubmission } from '@kineticdata/react';
+import { Button } from '../../atoms/Button.jsx';
 import { generateFormLayout } from '../../components/forms/FormLayout.jsx';
+import { KineticForm } from '../../components/kinetic-form/KineticForm.jsx';
+import { openConfirm } from '../../helpers/confirm.js';
+import { toastError, toastSuccess } from '../../helpers/toasts.js';
+import { callIfFn } from '../../helpers/index.js';
 
-export const Form = ({ review }) => {
+const generateDeleteDraftButton =
+  ({ listActions }) =>
+  ({ submission, backTo }) => {
+    const navigate = useNavigate();
+
+    if (
+      !submission ||
+      !['Service'].includes(submission.type) ||
+      submission.coreState !== 'Draft'
+    )
+      return null;
+
+    // Show delete button is submission is of type Service and is in Draft state
+    return (
+      <Button
+        variant="tertiary"
+        inverse
+        icon="trash"
+        onClick={() => {
+          openConfirm({
+            title: 'Delete Draft',
+            description: 'Are you sure you want to delete this draft request?',
+            acceptLabel: 'Delete',
+            accept: () =>
+              deleteSubmission({ id: submission.id }).then(({ error }) => {
+                if (error) {
+                  toastError({
+                    title: 'Failed to delete draft request',
+                    description: error.message,
+                  });
+                } else {
+                  toastSuccess({ title: 'Successfully deleted draft request' });
+                  callIfFn(listActions?.reload);
+                  navigate(backTo || '/requests', {
+                    state: { persistToasts: true },
+                  });
+                }
+              }),
+          });
+        }}
+        aria-label="Delete Draft"
+        title="Delete Draft"
+      />
+    );
+  };
+
+export const Form = ({ review, listActions }) => {
   const mobile = useSelector(state => state.view.mobile);
   const { kappSlug, formSlug, submissionId } = useParams();
   const portalKappSlug = useSelector(state => state.app.kappSlug);
@@ -17,7 +68,15 @@ export const Form = ({ review }) => {
     location.state?.backPath ||
     (submissionId ? '/requests' : mobile ? '/' : null);
 
-  const Layout = useMemo(() => generateFormLayout({ backTo }), []);
+  const DeleteDraftButton = useMemo(
+    () => generateDeleteDraftButton({ listActions }),
+    [listActions],
+  );
+
+  const Layout = useMemo(
+    () => generateFormLayout({ backTo, actionComponent: DeleteDraftButton }),
+    [backTo, DeleteDraftButton],
+  );
 
   const handleCompleted = useCallback(
     response => {

--- a/portal/src/pages/tickets/requests/RequestDetail.jsx
+++ b/portal/src/pages/tickets/requests/RequestDetail.jsx
@@ -37,7 +37,7 @@ const Activity = ({ first, last, mobile, icon, activity }) => {
     >
       <div
         className={clsx(
-          'absolute w-1 bg-success-500 h-full',
+          'absolute w-1 bg-success-500',
           '-left-4',
           'md:-left-[3.875rem]',
           {

--- a/portal/src/pages/tickets/requests/Requests.jsx
+++ b/portal/src/pages/tickets/requests/Requests.jsx
@@ -69,7 +69,10 @@ export const Requests = () => {
         path=":submissionId"
         element={<RequestDetail listActions={listActions} />}
       />
-      <Route path=":submissionId/edit" element={<Form />} />
+      <Route
+        path=":submissionId/edit"
+        element={<Form listActions={listActions} />}
+      />
       <Route path=":submissionId/review" element={<Form review={true} />} />
       <Route
         path="*"

--- a/portal/src/pages/tickets/requests/RequestsList.jsx
+++ b/portal/src/pages/tickets/requests/RequestsList.jsx
@@ -19,7 +19,7 @@ export const RequestsList = ({
   const mobile = useSelector(state => state.view.mobile);
 
   const { initialized, error, loading, data, pageNumber } = listData;
-  const { nextPage, previousPage } = listActions;
+  const { nextPage, previousPage, reload } = listActions;
 
   return (
     <>
@@ -60,7 +60,11 @@ export const RequestsList = ({
               )}
               {!loading &&
                 data.map(submission => (
-                  <TicketCard key={submission.id} submission={submission} />
+                  <TicketCard
+                    key={submission.id}
+                    submission={submission}
+                    reload={reload}
+                  />
                 ))}
               {!loading && data.length === 0 && (
                 <EmptyCard>There are no requests to show.</EmptyCard>


### PR DESCRIPTION
Added a delete button to the form page when viewing a draft request. 
Added a delete button to the requests lists that appears on hover or focus of a draft row. 
Added swipe delete functionality for mobile devices that allows swiping left on a draft record in the requests list to delete it. 
All of the above deletes show a confirmation popup. 
Implemented a useSwipe hook to handle swiping logic.