### PR TITLE
KP-8525: Final Changes to Dispatch Workflow

### DIFF
--- a/.github/workflows/portal-build-dispatch.yaml
+++ b/.github/workflows/portal-build-dispatch.yaml
@@ -103,12 +103,12 @@ jobs:
         with:
           node-version: 18
 
-      # # Install dependencies
+      # Install dependencies
       - name: Run Yarn Install
         working-directory: ${{ vars.SOURCE_DIRECTORY }}
         run: yarn install
 
-      # # Build the portal
+      # Build the portal
       - name: Run Yarn Build
         working-directory: ${{ vars.SOURCE_DIRECTORY }}
         run: yarn build


### PR DESCRIPTION
- Removed the `--dryrun`
- Removed setting the `acl`, doesn't appear to be needed to allow someone to view the bucket as long as the permission are set on the bucket itself.
- Fixed an erroneous space that was breaking the multi-line command.
- Change all refs from `bundle` to `portal`
- Use `/versions/...` instead of `/branches/...`

Squash this.