### PR TITLE
KP-8597 Added link to form settings for space admins and handling for canonical routes

### DIFF
--- a/portal/src/components/forms/FormLayout.jsx
+++ b/portal/src/components/forms/FormLayout.jsx
@@ -1,5 +1,6 @@
 import t from 'prop-types';
 import clsx from 'clsx';
+import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import { getAttributeValue } from '../../helpers/records.js';
 import { Button } from '../../atoms/Button.jsx';
@@ -32,6 +33,7 @@ export const generateFormLayout = ({
    *  render.
    */
   const FormLayout = ({ form, submission, content }) => {
+    const spaceAdmin = useSelector(state => state.app.profile?.spaceAdmin);
     const location = useLocation();
     const backPath = location.state?.backPath;
     const icon = getAttributeValue(form, 'Icon', 'forms');
@@ -80,8 +82,19 @@ export const generateFormLayout = ({
               )}
             </span>
           </div>
-          <div className="max-w-screen-md text-base md:text-h3 font-semibold">
-            {form?.name}
+          <div className="max-w-screen-md text-base md:text-h3 font-semibold flex gap-4 items-center text-center text-balance">
+            {form?.name}{' '}
+            {form && spaceAdmin && (
+              <a
+                className="outline-0 hover:text-secondary-400 focus-visible:text-secondary-400"
+                href={`/app/console#/kapps/${form.kapp?.slug}/forms/edit/${form.slug}/general`}
+                target="_blank"
+                rel="noreferrer"
+                aria-label="Open Form Settings in Platform Console"
+              >
+                <Icon name="settings-share" />
+              </a>
+            )}
           </div>
           <div className="max-w-screen-md text-sm md:text-base line-clamp-2">
             {form?.description}

--- a/portal/src/pages/PrivateRoutes.jsx
+++ b/portal/src/pages/PrivateRoutes.jsx
@@ -1,4 +1,4 @@
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes, useParams } from 'react-router-dom';
 import { Home } from './home/Home.jsx';
 import { Actions } from './tickets/actions/Actions.jsx';
 import { Requests } from './tickets/requests/Requests.jsx';
@@ -8,12 +8,42 @@ import { useSelector } from 'react-redux';
 import { DesktopHeader } from '../components/header/DesktopHeader.jsx';
 import { MobileFooter } from '../components/footer/MobileFooter.jsx';
 
+const Redirect = ({ to }) => {
+  const params = useParams();
+  return (
+    <Navigate
+      to={(typeof to === 'function' ? to(params) : to) || '/'}
+      replace={true}
+    />
+  );
+};
+
 export const PrivateRoutes = () => {
   const { mobile } = useSelector(state => state.view);
   return (
     <>
       {!mobile && <DesktopHeader></DesktopHeader>}
       <Routes>
+        {/* Canonical route for submissions */}
+        <Route
+          path="/kapps/:kappSlug/forms/:formSlug/submissions/:submissionId"
+          element={
+            <Redirect
+              to={params =>
+                `/kapps/${params.kappSlug}/forms/${params.formSlug}/${params.submissionId}`
+              }
+            />
+          }
+        />
+        {/* Canonical route for forms */}
+        <Route
+          path="/kapps/:kappSlug/forms/:formSlug/:submissionId?"
+          element={<Form />}
+        />
+        {/* Canonical route for kapps */}
+        <Route path="/kapps/:kappSlug" element={<Redirect to="/" />} />
+
+        {/* Portal routes */}
         <Route path="/actions/*" element={<Actions />} />
         <Route path="/requests/*" element={<Requests />} />
         <Route path="/forms/:formSlug/:submissionId?" element={<Form />} />


### PR DESCRIPTION
Add a link for space admins only that appears next to the form name when viewing a form, that takes them to the platform console form settings. 
Added routes for handling the canonical server routes.