### PR TITLE
KP-8742: Create integration connections and operations with existing ids

### DIFF
--- a/template/export/core/space/kapps/service-portal.json
+++ b/template/export/core/space/kapps/service-portal.json
@@ -4,7 +4,7 @@
     {
       "name": "Department Head",
       "values": [
-        "services.maanger@kineticdata.com"
+        "services.manager@kineticdata.com"
       ]
     }
   ],

--- a/template/export/core/space/kapps/service-portal/forms/request-a-ipad.json
+++ b/template/export/core/space/kapps/service-portal/forms/request-a-ipad.json
@@ -63,6 +63,13 @@
       "unique": false
     },
     {
+      "name": "values[Ipad Size]",
+      "parts": [
+        "values[Ipad Size]"
+      ],
+      "unique": false
+    },
+    {
       "name": "values[Text]",
       "parts": [
         "values[Text]"
@@ -138,6 +145,44 @@
           "required": false
         },
         {
+          "enabled": true,
+          "dataType": "string",
+          "defaultDataSource": "none",
+          "requiredMessage": null,
+          "name": "Ipad Size",
+          "choicesResourceName": null,
+          "omitWhenHidden": null,
+          "renderAttributes": {},
+          "renderType": "radio",
+          "pattern": null,
+          "defaultValue": null,
+          "visible": true,
+          "choices": [
+            {
+              "label": "16\"",
+              "value": "16\""
+            },
+            {
+              "label": "22\"",
+              "value": "22\""
+            },
+            {
+              "label": "24\"",
+              "value": "24\""
+            }
+          ],
+          "label": "Ipad Size",
+          "choicesResourceProperty": null,
+          "choicesRunIf": null,
+          "constraints": [],
+          "choicesDataSource": "custom",
+          "events": [],
+          "defaultResourceName": null,
+          "type": "field",
+          "key": "310c7735e2ea49ef8a6ba65120f22046",
+          "required": false
+        },
+        {
           "type": "section",
           "renderType": null,
           "name": "Widget",
@@ -209,7 +254,7 @@
         },
         {
           "name": "Signature Widget",
-          "code": "bundle.widgets.Signature({\n  container: K('section[Signature Widget]').element(),\n  field: K('field[Signature]'),\n  config: {\n    // Disable in review mode\n    disabled: K('form').reviewMode(),\n    // Modal Title\n    modalTitle: 'Sign your form',\n    // Label above signature pad\n    signaturePadLabel: 'Signature',\n    // Agreement text\n    agreementText: 'I understand this is a legal representation of my signature.',\n    // Button label for Save\n    savedButtonLabel: 'Save',\n    // Saved File Name\n    savedFileName: 'signature_widget',\n    // Button label for signature field\n    buttonLabel: 'Signature',\n    // Button label for Clear\n    clearButtonLabel: 'Clear',\n  },\n  id: 'sig'\n});",
+          "code": "bundle.widgets.Signature({\n  container: K('section[Signature Widget]').element(),\n  field: K('field[Signature]'),\n  config: {\n    // Disable in review mode\n    disabled: K('form').reviewMode(),\n    // Title of the signature modal\n    modalTitle: 'Sign your form',\n    // Label displayed above the signature pad\n    signaturePadLabel: 'Signature',\n    // Label for the full name input field\n    fullNameLabel: 'Full Name*',\n    // Agreement text displayed below the signature field\n    agreementText:\n      'I understand this is a legal representation of my signature.',\n    // Label for the save button\n    savedButtonLabel: 'Save',\n    //  Name of the saved signature file\n    savedFileName: 'signature_widget',\n    // Label for the button that opens the signature modal\n    buttonLabel: 'Signature',\n    // Label for the button that clears the signature\n    clearButtonLabel: 'Clear',\n  },\n  id: 'sig',\n});",
           "integrationResourceName": null,
           "action": "Custom",
           "integrationResourceProperty": "",

--- a/template/export/integrator/connections.json
+++ b/template/export/integrator/connections.json
@@ -1,5 +1,6 @@
 [
   {
+    "id": "b080b901-bb64-4be6-9853-edd15c47ca45",
     "name": "dev207658.service-now",
     "type": "http",
     "config": {
@@ -18,6 +19,7 @@
     "secrets": {},
     "operations": [
       {
+        "id": "95f495c2-4611-426b-aa21-b0dc184aa555",
         "name": "Get Incidents",
         "config": {
           "path": "/table/incident",
@@ -35,9 +37,11 @@
         },
         "outputs": {},
         "documentationLink": "",
+        "connectionId": "b080b901-bb64-4be6-9853-edd15c47ca45",
         "notes": ""
       },
       {
+        "id": "a30b6418-af4e-4c93-aa29-bcb12bc0fb44",
         "name": "Get Incident by sys_id",
         "config": {
           "path": "/table/incident/{{Sys Id}}",
@@ -76,9 +80,11 @@
           }
         },
         "documentationLink": "https://www.servicenow.com/docs/bundle/xanadu-api-reference/page/integrate/inbound-rest/task/t_GetStartedRetrieveExisting.html",
+        "connectionId": "b080b901-bb64-4be6-9853-edd15c47ca45",
         "notes": ""
       },
       {
+        "id": "ca6d3c30-d335-46a9-86fb-8f57fed0fffb",
         "name": "Create Incident Work Notes",
         "config": {
           "path": "/table/incident/{{SYS ID}}",
@@ -109,9 +115,11 @@
           }
         },
         "documentationLink": "https://www.servicenow.com/docs/bundle/xanadu-api-reference/page/integrate/inbound-rest/task/t_GetStartedCreateInt.html",
+        "connectionId": "b080b901-bb64-4be6-9853-edd15c47ca45",
         "notes": ""
       },
       {
+        "id": "9d441062-fbb2-4287-9844-9dfb33eccd66",
         "name": "Create Incident",
         "config": {
           "path": "/table/incident",
@@ -142,9 +150,11 @@
           }
         },
         "documentationLink": "https://www.servicenow.com/docs/bundle/xanadu-api-reference/page/integrate/inbound-rest/task/t_GetStartedCreateInt.html",
+        "connectionId": "b080b901-bb64-4be6-9853-edd15c47ca45",
         "notes": ""
       },
       {
+        "id": "b06d71f6-78d6-4d86-be76-18a6f7f0456c",
         "name": "Get Journal Entries by System ID and Element Type",
         "config": {
           "path": "/table/sys_journal_field",
@@ -189,9 +199,76 @@
           }
         },
         "documentationLink": "https://www.servicenow.com/docs/bundle/xanadu-api-reference/page/integrate/inbound-rest/task/t_GetStartedRetrieveExisting.html",
+        "connectionId": "b080b901-bb64-4be6-9853-edd15c47ca45",
         "notes": "Journal Entries contain several different types of comments or data.  \n\nThe Journal Element parameter references this type. Common values are:\n-work_notes\n-comments\n- approval_history\n\n\nThe Element ID parameter is the sys_id of the related record such as the Incident record"
       },
       {
+        "id": "bfd78b32-28ae-43c5-86ca-b68fc4513f53",
+        "name": "Create Change Task",
+        "config": {
+          "path": "/table/change_task",
+          "params": {},
+          "body": {
+            "raw": "{\n\"change_request\":\"{{Change Sys Id}}\",\n\"short_description\":\"{{Short Description}}\"\n}",
+            "bodyType": "raw"
+          },
+          "headers": {},
+          "configType": "http",
+          "method": "POST",
+          "includeEmptyParams": false,
+          "followRedirect": false,
+          "streamResponse": false
+        },
+        "outputs": {},
+        "documentationLink": "",
+        "connectionId": "b080b901-bb64-4be6-9853-edd15c47ca45",
+        "notes": ""
+      },
+      {
+        "id": "846933d8-0fd5-48b6-a3fa-a5c712f1245f",
+        "name": "Get Change by Sys Id",
+        "config": {
+          "path": "/table/change_request/{{Sys Id}}",
+          "params": {
+            "sysparm_display_value": "true"
+          },
+          "body": {
+            "form": {},
+            "bodyType": "www_form_urlencoded"
+          },
+          "headers": {
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+          },
+          "configType": "http",
+          "method": "GET",
+          "includeEmptyParams": false,
+          "followRedirect": false,
+          "streamResponse": false
+        },
+        "outputs": {
+          "Error": {
+            "value": "body.error?.detail"
+          },
+          "Message": {
+            "value": "body.error?.message"
+          },
+          "Result": {
+            "value": "body.result"
+          },
+          "Status": {
+            "value": "body.status"
+          },
+          "Status Code": {
+            "value": "statusCode"
+          }
+        },
+        "documentationLink": "https://www.servicenow.com/docs/bundle/xanadu-api-reference/page/integrate/inbound-rest/task/t_GetStartedRetrieveExisting.html",
+        "connectionId": "b080b901-bb64-4be6-9853-edd15c47ca45",
+        "notes": ""
+      },
+      {
+        "id": "60fbef43-571c-4a09-bca6-58c90356d54f",
         "name": "Create Incident Using Template",
         "config": {
           "path": "/table/incident",
@@ -222,11 +299,35 @@
           }
         },
         "documentationLink": "https://www.servicenow.com/docs/bundle/xanadu-api-reference/page/integrate/inbound-rest/task/t_GetStartedCreateInt.html",
+        "connectionId": "b080b901-bb64-4be6-9853-edd15c47ca45",
+        "notes": ""
+      },
+      {
+        "id": "ab0b0561-ddf3-4e67-9c4f-59afa1ade47a",
+        "name": "Update Change State",
+        "config": {
+          "path": "/table/change_request/{{Sys Id}}",
+          "params": {},
+          "body": {
+            "raw": "{\n\"state\":\"{{State}}\"\n}",
+            "bodyType": "raw"
+          },
+          "headers": {},
+          "configType": "http",
+          "method": "PUT",
+          "includeEmptyParams": false,
+          "followRedirect": false,
+          "streamResponse": false
+        },
+        "outputs": {},
+        "documentationLink": "",
+        "connectionId": "b080b901-bb64-4be6-9853-edd15c47ca45",
         "notes": ""
       }
     ]
   },
   {
+    "id": "1415539c-bb98-48bb-ad33-11be25189ad0",
     "name": "Kinetic Platform",
     "type": "http",
     "config": {
@@ -245,6 +346,7 @@
     "secrets": {},
     "operations": [
       {
+        "id": "c69716b8-f9dc-45f1-ab3f-2eed5d2a22b8",
         "name": "Get Submission",
         "config": {
           "path": "/submissions/{{Submission Id}}",
@@ -291,9 +393,11 @@
           }
         },
         "documentationLink": "",
+        "connectionId": "1415539c-bb98-48bb-ad33-11be25189ad0",
         "notes": ""
       },
       {
+        "id": "3ad53519-e058-48a1-b114-5745533526ad",
         "name": "Update Submission",
         "config": {
           "path": "/submissions/{{Submission Id}}",
@@ -314,9 +418,11 @@
         },
         "outputs": {},
         "documentationLink": "",
+        "connectionId": "1415539c-bb98-48bb-ad33-11be25189ad0",
         "notes": ""
       },
       {
+        "id": "ea6546cb-e8e7-4083-85c9-cb535b81e58a",
         "name": "Get form Approvers by Submission Id",
         "config": {
           "path": "/submissions/{{Submission Id}}",
@@ -344,9 +450,11 @@
           }
         },
         "documentationLink": "",
+        "connectionId": "1415539c-bb98-48bb-ad33-11be25189ad0",
         "notes": ""
       },
       {
+        "id": "018c5373-af69-48f2-9ebb-5870ec8a4e3b",
         "name": "Get Form Attributes Map",
         "config": {
           "path": "/kapps/{{Kapp Slug}}/forms/{{Form Slug}}",
@@ -366,9 +474,11 @@
         },
         "outputs": {},
         "documentationLink": "",
+        "connectionId": "1415539c-bb98-48bb-ad33-11be25189ad0",
         "notes": ""
       },
       {
+        "id": "cee2ccc2-76d7-4ed4-8f90-b90dd6d2351b",
         "name": "Get Test",
         "config": {
           "path": "/submissions/35230208-9702-11ef-85d7-534218953e47",
@@ -392,9 +502,11 @@
           }
         },
         "documentationLink": "",
+        "connectionId": "1415539c-bb98-48bb-ad33-11be25189ad0",
         "notes": ""
       },
       {
+        "id": "0ef69bcb-c052-4b16-9814-166c3eef85ed",
         "name": "Update Submission - Values Only",
         "config": {
           "path": "/submissions/{{Submission Id}}",
@@ -415,9 +527,11 @@
         },
         "outputs": {},
         "documentationLink": "",
+        "connectionId": "1415539c-bb98-48bb-ad33-11be25189ad0",
         "notes": ""
       },
       {
+        "id": "7ad51a20-8bab-422b-a0f7-247e082dccd5",
         "name": "Get Space",
         "config": {
           "path": "/space",
@@ -450,9 +564,11 @@
           }
         },
         "documentationLink": "",
+        "connectionId": "1415539c-bb98-48bb-ad33-11be25189ad0",
         "notes": ""
       },
       {
+        "id": "b5e75933-339d-4d6a-8c58-da509be53e1b",
         "name": "Get Approval Values",
         "config": {
           "path": "/submissions/{{Submission Id}}",
@@ -484,9 +600,11 @@
           }
         },
         "documentationLink": "",
+        "connectionId": "1415539c-bb98-48bb-ad33-11be25189ad0",
         "notes": ""
       },
       {
+        "id": "85be2cba-ee7e-4f36-8fd9-6c383ddb5b9a",
         "name": "Get Task Values",
         "config": {
           "path": "/submissions/{{Submission Id}}",
@@ -515,9 +633,11 @@
           }
         },
         "documentationLink": "",
+        "connectionId": "1415539c-bb98-48bb-ad33-11be25189ad0",
         "notes": ""
       },
       {
+        "id": "023fbddc-ec6e-49dd-9729-d1f64af70deb",
         "name": "Update Submission Activity",
         "config": {
           "path": "/submissions/{{Submission Id}}/activities/{{Activity Id}}",
@@ -544,9 +664,11 @@
           }
         },
         "documentationLink": "",
+        "connectionId": "1415539c-bb98-48bb-ad33-11be25189ad0",
         "notes": ""
       },
       {
+        "id": "771f279a-988d-4b91-9b8f-85861c5c13fe",
         "name": "Get User",
         "config": {
           "path": "/users/{{Username}}",
@@ -582,9 +704,11 @@
           }
         },
         "documentationLink": "",
+        "connectionId": "1415539c-bb98-48bb-ad33-11be25189ad0",
         "notes": ""
       },
       {
+        "id": "92b6a327-5f5a-4377-80f7-b7223bd787ac",
         "name": "Create Submission Activity",
         "config": {
           "path": "/submissions/{{Submission Id}}/activities",
@@ -614,9 +738,11 @@
           }
         },
         "documentationLink": "",
+        "connectionId": "1415539c-bb98-48bb-ad33-11be25189ad0",
         "notes": ""
       },
       {
+        "id": "16f70295-86eb-4624-b2f8-7bc2fa62de96",
         "name": "List Users",
         "config": {
           "path": "/users/",
@@ -649,9 +775,11 @@
           }
         },
         "documentationLink": "",
+        "connectionId": "1415539c-bb98-48bb-ad33-11be25189ad0",
         "notes": ""
       },
       {
+        "id": "ffbbe197-1247-4b77-a5a3-335f60a95b18",
         "name": "_test",
         "config": {
           "path": "/users/{{Username}}",
@@ -687,9 +815,11 @@
           }
         },
         "documentationLink": "",
+        "connectionId": "1415539c-bb98-48bb-ad33-11be25189ad0",
         "notes": ""
       },
       {
+        "id": "9c3a3309-536e-4e3d-a3b3-be072d652a51",
         "name": "List Departments",
         "config": {
           "path": "/teams",
@@ -720,9 +850,11 @@
           }
         },
         "documentationLink": "",
+        "connectionId": "1415539c-bb98-48bb-ad33-11be25189ad0",
         "notes": ""
       },
       {
+        "id": "625584c3-32e0-415f-a181-4405057e5fca",
         "name": "Search Users",
         "config": {
           "path": "/users",
@@ -750,9 +882,11 @@
           }
         },
         "documentationLink": "",
+        "connectionId": "1415539c-bb98-48bb-ad33-11be25189ad0",
         "notes": ""
       },
       {
+        "id": "e20b8b5d-da67-410b-a527-bd3ae1cfe07b",
         "name": "Get Team",
         "config": {
           "path": "teams/{{Slug}}",
@@ -798,9 +932,11 @@
           }
         },
         "documentationLink": "",
+        "connectionId": "1415539c-bb98-48bb-ad33-11be25189ad0",
         "notes": ""
       },
       {
+        "id": "e8f73406-d95b-44f0-b3fd-2731e7ccebf3",
         "name": "Get User Password Reset Token",
         "config": {
           "path": "/users/{{User Name}}/passwordResetToken",
@@ -822,6 +958,7 @@
           }
         },
         "documentationLink": "",
+        "connectionId": "1415539c-bb98-48bb-ad33-11be25189ad0",
         "notes": ""
       }
     ]

--- a/template/tooling/integrator.rb
+++ b/template/tooling/integrator.rb
@@ -84,12 +84,9 @@ def sanitize_http_basic(connection)
 end
 
 def delete_metadata(item)
-  item.delete("id")
   item.delete("insertedAt")
   item.delete("updatedAt")
   item.delete("lockVersion")
-  # operation
-  item.delete("connectionId")
   # connection
   item.delete("status")
   item


### PR DESCRIPTION
Connections and Operations are now exported with existing ids. These ids will be used when importing to new space so forms and workflows don't need to be updated with new ids.

Integrator 6.1.3 will support creating connections and operations with existing ids. Prior to 6.1.3, these ids are ignored if they are passed in with the payload.