### PR TITLE
KP-8888 Refactored how widgets manage their APIs

### DIFF
--- a/portal/src/atoms/Menu.jsx
+++ b/portal/src/atoms/Menu.jsx
@@ -144,7 +144,7 @@ export const Menu = ({
         </ArkMenu.Trigger>
       )}
       <ArkMenu.Positioner>
-        <ArkMenu.Content className="py-2 bg-white border border-gray-600 rounded min-w-[10rem] outline-0 shadow-lg">
+        <ArkMenu.Content className="py-2 bg-white border border-gray-600 rounded min-w-[10rem] outline-0 shadow-lg z-30">
           <Items items={items} />
         </ArkMenu.Content>
       </ArkMenu.Positioner>

--- a/portal/src/components/kinetic-form/widgets/signature.js
+++ b/portal/src/components/kinetic-form/widgets/signature.js
@@ -1,4 +1,4 @@
-import { useState, forwardRef, useRef } from 'react';
+import { useState, forwardRef, useRef, useCallback, useEffect } from 'react';
 import clsx from 'clsx';
 import t from 'prop-types';
 import { Modal } from '../../../atoms/Modal.jsx';
@@ -64,16 +64,14 @@ const SignatureComponent = forwardRef(
     );
 
     // Function to get the value
-    const getValue = () => {
-      return field.value();
-    };
+    const getValue = useCallback(() => field.value(), [field]);
 
     // Function to reset the value externally
-    const reset = () => {
+    const reset = useCallback(() => {
       setImageUrl('');
       setSavedSignature('');
       field.value([]);
-    };
+    }, [field]);
 
     const generateSignatureImage = () => {
       const canvas = canvasRef.current;
@@ -155,14 +153,15 @@ const SignatureComponent = forwardRef(
       (activeTab === 'draw' && !imageUrl) ||
       (activeTab === 'type' && (!selectedStyle || !fullName));
 
+    // Define API ref
+    const api = useRef({ getValue, reset });
+    // Update API ref when its contents change
+    useEffect(() => {
+      Object.assign(api.current, { getValue, reset });
+    }, [getValue, reset]);
+
     return (
-      <WidgetAPI
-        ref={ref}
-        api={{
-          getValue,
-          reset,
-        }}
-      >
+      <WidgetAPI ref={ref} api={api.current}>
         <div className={clsx('flex flex-col')}>
           <div className="flex items-center justify-between w-full">
             <button
@@ -392,6 +391,9 @@ export const Signature = ({ container, field, config, id } = {}) => {
       id,
     });
   }
+  return Promise.reject(
+    'The Signature widget parameters are invalid. See the console for more details.',
+  );
 };
 
 /**

--- a/portal/src/components/kinetic-form/widgets/subform.js
+++ b/portal/src/components/kinetic-form/widgets/subform.js
@@ -174,8 +174,15 @@ const KineticSubformComponent = forwardRef(
       return kFormRef.current?.serialize();
     }, []);
 
+    // Define API ref
+    const api = useRef({ kForm, toasterId, data: getData });
+    // Update API ref when its contents change
+    useEffect(() => {
+      Object.assign(api.current, { toasterId });
+    }, [toasterId]);
+
     return (
-      <WidgetAPI ref={ref} api={{ kForm, toasterId, data: getData }}>
+      <WidgetAPI ref={ref} api={api.current}>
         <KineticLib globals={globals} locale="en">
           <SubformLayout
             inline={inline}
@@ -513,6 +520,9 @@ export const Subform = ({ container, config, id } = {}) => {
       id,
     });
   }
+  return Promise.reject(
+    'The Subform widget parameters are invalid. See the console for more details.',
+  );
 };
 
 /**

--- a/portal/src/components/kinetic-form/widgets/table.js
+++ b/portal/src/components/kinetic-form/widgets/table.js
@@ -1129,8 +1129,15 @@ const TableComponent = forwardRef(
       ],
     );
 
+    // Define API ref
+    const api = useRef({ ...tableApi });
+    // Update API ref when its contents change
+    useEffect(() => {
+      Object.assign(api.current, tableApi);
+    }, [tableApi]);
+
     return (
-      <WidgetAPI ref={ref} api={tableApi}>
+      <WidgetAPI ref={ref} api={api.current}>
         <TableRenderer
           currentTableData={currentTableData}
           currentColumns={currentColumns}
@@ -1325,6 +1332,7 @@ const validateConfig = (config, field) => {
  * instance of the widget and render it into the provided container.
  *
  * @param {HTMLElement} container HTML Element into which to render the widget.
+ * @param {object} field Kinetic field object to store the data in.
  * @param {object} config Configuration object for the widget.
  * @param {string} [id] Optional id that can be used to retrieve a reference to
  *  the widget's API functions using the `Table.get` function.
@@ -1342,4 +1350,7 @@ export const Table = ({ container, field, config, id } = {}) => {
       id,
     });
   }
+  return Promise.reject(
+    'The Table widget parameters are invalid. See the console for more details.',
+  );
 };


### PR DESCRIPTION
Updated the widget code to allow for using a mutable ref for defining an API object so that it can be mutated as the component state changes, which allows for the end user to always have access to the latest state. 
Updated widgets to return a promise that is resolved with their API after the widget is initialized.