### PR TITLE
updated references to credentials

### DIFF
--- a/template/tooling/export.rb
+++ b/template/tooling/export.rb
@@ -87,8 +87,8 @@ integrator_sdk = KineticSdk::Integrator.new({
   password: vars["core"]["service_user_password"],
   options: http_options.merge({
     export_directory: "#{integrator_path}",
-    oauth_client_id: vars["core"]["service_user_username"],
-    oauth_client_secret: vars["core"]["service_user_password"]
+    oauth_client_id: vars["http_options"]["oauth_client_id"],
+    oauth_client_secret: vars["http_options"]["oauth_client_secret"]
   })
 })
 task_sdk = KineticSdk::Task.new({


### PR DESCRIPTION
It appears that the oauth_client_id and oauth_client_secret were set to the service_users credentials.

The result was that the Oauth Client also needed to exist as a User with the same credentials. I assume this was not the design intent.